### PR TITLE
fix(release): add ids names for archives

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -88,7 +88,8 @@ archives:
   - id: provider-services-version
     builds:
       - darwin-universal
-      - provider-services-linux
+      - provider-services-linux-arm64
+      - provider-services-linux-amd64
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     wrap_in_directory: true
     format: zip


### PR DESCRIPTION
linux_arm64.zip was missing from the artifacts

Signed-off-by: Artur Troian <troian.ap@gmail.com>